### PR TITLE
ninja: use host's ninja if it exists

### DIFF
--- a/core/ninja.mk
+++ b/core/ninja.mk
@@ -1,4 +1,7 @@
-NINJA ?= prebuilts/ninja/$(HOST_PREBUILT_TAG)/ninja
+NINJA ?= $(shell which ninja)
+ifeq ($(NINJA),)
+  NINJA := prebuilts/ninja/$(HOST_PREBUILT_TAG)/ninja
+endif
 
 ifeq ($(USE_SOONG),true)
 USE_SOONG_FOR_KATI := true


### PR DESCRIPTION
- For whatever reason mainline ninja improves my build significantly
- Allow users to bust out of using whatever binary is provided with the
  build system and use their own copy if they have it installed

Change-Id: I14dbb7b9d8a028d1b0f16e136a8310584df329be
